### PR TITLE
fix: mutex pointer reset in Destroy method

### DIFF
--- a/src/libsql/AsyncSQL.cpp
+++ b/src/libsql/AsyncSQL.cpp
@@ -68,7 +68,7 @@ void CAsyncSQL::Destroy()
 		::DeleteCriticalSection(m_mtxResult);
 #endif
 		delete m_mtxResult;
-		m_mtxQuery = NULL;
+		m_mtxResult = NULL;
 	}
 }
 


### PR DESCRIPTION
Corrects the pointer reset in CAsyncSQL::Destroy by setting m_mtxResult to NULL instead of m_mtxQuery after deleting m_mtxResult.