### PR TITLE
feat(build): add PCH support, disabled CMAKE_CXX_EXTENSIONS and updated CMake version 3.15 to 3.16 for using PCH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
-﻿cmake_minimum_required(VERSION 3.15)
+﻿cmake_minimum_required(VERSION 3.16)
 project(m2dev-server-src)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # ASan support
 option(ENABLE_ASAN "Enable AddressSanitizer" OFF)

--- a/src/db/CMakeLists.txt
+++ b/src/db/CMakeLists.txt
@@ -1,8 +1,9 @@
-﻿file(GLOB_RECURSE DB_SOURCES "*.h" "*.cpp")
+file(GLOB_RECURSE DB_SOURCES "*.h" "*.cpp")
 
 add_executable(db ${DB_SOURCES})
 
 target_compile_definitions(db PRIVATE GIT_DESCRIBE="${GIT_DESCRIBE_VERSION}")
+target_precompile_headers(db PRIVATE stdafx.h)
 
 target_link_libraries(db 
 	common

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -1,8 +1,9 @@
-﻿file(GLOB_RECURSE GAME_SOURCES "*.h" "*.c" "*.cpp")
+file(GLOB_RECURSE GAME_SOURCES "*.h" "*.c" "*.cpp")
 
 add_executable(game ${GAME_SOURCES})
 
 target_compile_definitions(game PRIVATE GIT_DESCRIBE="${GIT_DESCRIBE_VERSION}")
+target_precompile_headers(game PRIVATE stdafx.h)
 
 target_link_libraries(game 
 	common 

--- a/src/libsql/CMakeLists.txt
+++ b/src/libsql/CMakeLists.txt
@@ -1,6 +1,7 @@
-﻿file(GLOB_RECURSE LIBSQL_SOURCES "*.h" "*.cpp")
+file(GLOB_RECURSE LIBSQL_SOURCES "*.h" "*.cpp")
 
 add_library(libsql STATIC ${LIBSQL_SOURCES})
+target_precompile_headers(libsql PRIVATE stdafx.h)
 
 target_link_libraries(libsql 
 	common

--- a/src/libthecore/CMakeLists.txt
+++ b/src/libthecore/CMakeLists.txt
@@ -1,6 +1,7 @@
-﻿file(GLOB_RECURSE LIBTHECORE_SOURCES "*.h" "*.cpp")
+file(GLOB_RECURSE LIBTHECORE_SOURCES "*.h" "*.cpp")
 
 add_library(libthecore STATIC ${LIBTHECORE_SOURCES})
+target_precompile_headers(libthecore PRIVATE stdafx.h)
 
 target_link_libraries(libthecore 
 	common


### PR DESCRIPTION
Reason of set CXX_EXTENSION to OFF: briefly; disabling compiler-specific plugins. This improves cross-platform compatibility and guarantees that code remains valid standard C++
https://cmake.org/cmake/help/latest/prop_tgt/CXX_EXTENSIONS.html

--------------------------------------------------

Benchmark results (Clean Release Build):
- Tested on: Windows x64
- Toolchain: MSVC (Visual Studio 2026)
- Method: Full clean rebuild for both scenarios.
==================================================
BENCHMARK RESULTS
==================================================
With PCH:    44.87s
Without PCH: 93.46s
--------------------------------------------------
 Improvement: ~2x Speedup
 
 https://cmake.org/cmake/help/latest/command/target_precompile_headers.html#command:target_precompile_headers