### PR TITLE
add handling for other linux distros

### DIFF
--- a/src/db/CMakeLists.txt
+++ b/src/db/CMakeLists.txt
@@ -16,7 +16,10 @@ target_link_libraries(db
 )
 
 if (WIN32)
-	target_link_libraries(db ws2_32)
+    target_link_libraries(db ws2_32)
 else()
-	target_link_libraries(db pthread md)
+    target_link_libraries(db pthread)
+    if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+        target_link_libraries(db md)
+    endif()
 endif()

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -18,7 +18,10 @@ target_link_libraries(game
 )
 
 if (WIN32)
-	target_link_libraries(game ws2_32)
+    target_link_libraries(game ws2_32)
 else()
-	target_link_libraries(game pthread md)
+    target_link_libraries(game pthread)
+    if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+        target_link_libraries(game md)
+    endif()
 endif()

--- a/src/game/ClientPackageCryptInfo.cpp
+++ b/src/game/ClientPackageCryptInfo.cpp
@@ -2,7 +2,7 @@
 #include "ClientPackageCryptInfo.h"
 #include "common/stl.h"
 
-#ifndef OS_FREEBSD
+#ifdef OS_WINDOWS
 #include "libthecore/xdirent.h"
 #endif
 

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -520,7 +520,9 @@ int start(int argc, char **argv)
 				printf("IP %s\n", g_szPublicIP);
 
 				optind++;
-				optreset = 1;
+				#ifdef OS_FREEBSD
+                	optreset = 1;
+				#endif
 				break;
 
 			case 'p': // port
@@ -535,7 +537,9 @@ int start(int argc, char **argv)
 				printf("port %d\n", mother_port);
 
 				optind++;
-				optreset = 1;
+				#ifdef OS_FREEBSD
+                	optreset = 1;
+				#endif
 				break;
 
 				// LOCALE_SERVICE
@@ -544,7 +548,9 @@ int start(int argc, char **argv)
 					if (optind < argc)
 					{
 						st_localeServiceName = argv[optind++];
-						optreset = 1;
+						#ifdef OS_FREEBSD
+							optreset = 1;
+						#endif
 					}
 				}
 				break;

--- a/src/libthecore/fdwatch.h
+++ b/src/libthecore/fdwatch.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-#ifndef OS_WINDOWS
+#ifndef __USE_SELECT__
 
     typedef struct fdwatch		FDWATCH;
     typedef struct fdwatch *	LPFDWATCH;

--- a/src/libthecore/main.cpp
+++ b/src/libthecore/main.cpp
@@ -49,7 +49,9 @@ int thecore_init(int fps, HEARTFUNC heartbeat_func)
     srand(time(0));
 #else
     srandom(time(0) + getpid() + getuid());
+#ifdef OS_FREEBSD
     srandomdev();
+#endif
 #endif
 
 	log_init();

--- a/src/libthecore/signal.cpp
+++ b/src/libthecore/signal.cpp
@@ -4,7 +4,7 @@
 void signal_setup() {}
 void signal_timer_disable() {}
 void signal_timer_enable(int timeout_seconds) {}
-#elif OS_FREEBSD
+#else
 #define RETSIGTYPE void
 
 RETSIGTYPE reap(int sig)

--- a/src/qc/CMakeLists.txt
+++ b/src/qc/CMakeLists.txt
@@ -7,7 +7,10 @@ target_link_libraries(qc
 )
 
 if (WIN32)
-	target_link_libraries(qc ws2_32)
+    target_link_libraries(qc ws2_32)
 else()
-	target_link_libraries(qc pthread md)
+    target_link_libraries(qc pthread)
+    if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+        target_link_libraries(qc md)
+    endif()
 endif()

--- a/src/qc/qc.cpp
+++ b/src/qc/qc.cpp
@@ -29,6 +29,7 @@ extern "C"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <cstring>
 
 #include "crc32.h"
 


### PR DESCRIPTION
Fix Linux build compatibility

Fixed platform-specific compilation errors preventing Linux builds:

- fdwatch.h: Changed OS_WINDOWS to __USE_SELECT__ to match implementation
- signal.cpp: Fixed #elif OS_FREEBSD to #else for non-Windows platforms  
- ClientPackageCryptInfo.cpp: Changed xdirent.h include to #ifdef OS_WINDOWS
- main.cpp: Wrapped BSD-only srandomdev() and optreset in OS_FREEBSD guards
- CMakeLists.txt: Made libmd linking conditional on FreeBSD only
- qc.cpp: Added #include <cstring> for strlen() and strcmp()

Successfully builds on Linux while maintaining Windows and FreeBSD compatibility.