### PR TITLE
Auto potion safeguards

### DIFF
--- a/src/game/char.cpp
+++ b/src/game/char.cpp
@@ -114,6 +114,9 @@ CHARACTER::CHARACTER()
 	m_stateIdle.Set(this, &CHARACTER::BeginStateEmpty, &CHARACTER::StateIdle, &CHARACTER::EndStateEmpty);
 	m_stateMove.Set(this, &CHARACTER::BeginStateEmpty, &CHARACTER::StateMove, &CHARACTER::EndStateEmpty);
 	m_stateBattle.Set(this, &CHARACTER::BeginStateEmpty, &CHARACTER::StateBattle, &CHARACTER::EndStateEmpty);
+#ifdef FIX_POS_SYNC
+	m_stateSyncing.Set(this, &CHARACTER::BeginStateEmpty, &CHARACTER::StateSyncing, &CHARACTER::EndStateEmpty);
+#endif
 
 	Initialize();
 }
@@ -657,6 +660,25 @@ void CHARACTER::OpenMyShop(const char * c_pszSign, TShopItemTable * pTable, BYTE
 				ChatPacket(CHAT_TYPE_INFO, LC_TEXT("사용중인 아이템은 개인상점에서 판매할 수 없습니다."));
 				return;
 			}
+
+			// MR-3: Deactivate auto potions if active and being sold
+			switch (pkItem->GetVnum())
+			{
+				case ITEM_AUTO_HP_RECOVERY_S:
+				case ITEM_AUTO_HP_RECOVERY_M:
+				case ITEM_AUTO_HP_RECOVERY_L:
+				case ITEM_AUTO_HP_RECOVERY_X:
+				case ITEM_AUTO_SP_RECOVERY_S:
+				case ITEM_AUTO_SP_RECOVERY_M:
+				case ITEM_AUTO_SP_RECOVERY_L:
+				case ITEM_AUTO_SP_RECOVERY_X:
+					if (pkItem->GetSocket(0) == 1)
+						pkItem->SetSocket(0, 0);
+					break;
+				default:
+					break;
+			}
+			// MR-3: -- END OF -- Deactivate auto potions if active and being sold
 
 			// MYSHOP_PRICE_LIST
 			itemkind[pkItem->GetVnum()] = (pTable + i)->price / pkItem->GetCount();

--- a/src/game/char_battle.cpp
+++ b/src/game/char_battle.cpp
@@ -1077,6 +1077,25 @@ void CHARACTER::ItemDropPenalty(LPCHARACTER pkKiller)
 				if (IS_SET(pkItem->GetAntiFlag(), ITEM_ANTIFLAG_GIVE | ITEM_ANTIFLAG_PKDROP))
 					continue;
 
+				// MR-3: Auto-deactivate auto potions before dropping (death penalty)
+				switch (pkItem->GetVnum())
+				{
+					case ITEM_AUTO_HP_RECOVERY_S:
+					case ITEM_AUTO_HP_RECOVERY_M:
+					case ITEM_AUTO_HP_RECOVERY_L:
+					case ITEM_AUTO_HP_RECOVERY_X:
+					case ITEM_AUTO_SP_RECOVERY_S:
+					case ITEM_AUTO_SP_RECOVERY_M:
+					case ITEM_AUTO_SP_RECOVERY_L:
+					case ITEM_AUTO_SP_RECOVERY_X:
+						if (pkItem->GetSocket(0) == 1)
+							pkItem->SetSocket(0, 0);
+						break;
+					default:
+						break;
+				}
+				// MR-3: -- END OF -- Auto-deactivate auto potions before dropping (death penalty)
+
 				SyncQuickslot(QUICKSLOT_TYPE_ITEM, vec_bSlots[i], 255);
 				vec_item.push_back(std::make_pair(pkItem->RemoveFromCharacter(), INVENTORY));
 			}
@@ -1108,16 +1127,34 @@ void CHARACTER::ItemDropPenalty(LPCHARACTER pkKiller)
 			if (iQty)
 				iQty = number(1, iQty);
 
-			for (i = 0; i < iQty; ++i)
-			{
-				pkItem = GetWear(vec_bSlots[i]);
+			   for (i = 0; i < iQty; ++i)
+			   {
+				   pkItem = GetWear(vec_bSlots[i]);
 
-				if (IS_SET(pkItem->GetAntiFlag(), ITEM_ANTIFLAG_GIVE | ITEM_ANTIFLAG_PKDROP))
-					continue;
+				   if (IS_SET(pkItem->GetAntiFlag(), ITEM_ANTIFLAG_GIVE | ITEM_ANTIFLAG_PKDROP))
+					   continue;
 
-				SyncQuickslot(QUICKSLOT_TYPE_ITEM, vec_bSlots[i], 255);
-				vec_item.push_back(std::make_pair(pkItem->RemoveFromCharacter(), EQUIPMENT));
-			}
+				   // MR-3: Auto-deactivate auto potions before dropping (death penalty)
+				   switch (pkItem->GetVnum())
+				   {
+					   case ITEM_AUTO_HP_RECOVERY_S:
+					   case ITEM_AUTO_HP_RECOVERY_M:
+					   case ITEM_AUTO_HP_RECOVERY_L:
+					   case ITEM_AUTO_HP_RECOVERY_X:
+					   case ITEM_AUTO_SP_RECOVERY_S:
+					   case ITEM_AUTO_SP_RECOVERY_M:
+					   case ITEM_AUTO_SP_RECOVERY_L:
+					   case ITEM_AUTO_SP_RECOVERY_X:
+						   if (pkItem->GetSocket(0) == 1)
+							   pkItem->SetSocket(0, 0);
+						   break;
+					   default:
+						   break;
+				   }
+
+				   SyncQuickslot(QUICKSLOT_TYPE_ITEM, vec_bSlots[i], 255);
+				   vec_item.push_back(std::make_pair(pkItem->RemoveFromCharacter(), EQUIPMENT));
+			   }
 		}
 	}
 

--- a/src/game/item.cpp
+++ b/src/game/item.cpp
@@ -295,7 +295,7 @@ LPITEM CItem::RemoveFromCharacter()
 
 	LPCHARACTER pOwner = m_pOwner;
 
-	if (m_bEquipped)	// 장착되었는가?
+	if (m_bEquipped) // 장착되었는가?
 	{
 		Unequip();
 		//pOwner->UpdatePacket();
@@ -323,6 +323,21 @@ LPITEM CItem::RemoveFromCharacter()
 					sys_err("CItem::RemoveFromCharacter: Invalid Item Position");
 				else
 				{
+					// MR-3: Auto-deactivate auto potions before selling to vendors/removing
+					// Auto potion deactivation for NPC sell and similar removals
+					// Only deactivate if not from safebox or mall
+					if (GetWindow() != SAFEBOX && GetWindow() != MALL)
+					{
+						// Check for auto potion vnums (50200, 50201, 50202)
+						DWORD vnum = GetVnum();
+						if (vnum == 50200 || vnum == 50201 || vnum == 50202)
+						{
+							// Set socket 0 to 0 (deactivate)
+							SetSocket(0, 0);
+						}
+					}
+					// MR-3: -- END OF -- Auto-deactivate auto potions before selling to vendors/removing
+					
 					pOwner->SetItem(cell, NULL);
 				}
 			}


### PR DESCRIPTION
Auto-disable auto potions for

- Putting them into safebox
- Being part of an accepted trade
- Being sold to an NPC
- Being part of the items list when a private shop opens