### PR TITLE
Add EventFlag-based quest enable/disable system

### DIFF
--- a/src/game/questmanager.h
+++ b/src/game/questmanager.h
@@ -157,6 +157,7 @@ namespace quest
 
 			void		SetEventFlag(const string& name, int value);
 			int			GetEventFlag(const string& name);
+			bool		IsEventFlagSet(const string& name);  // Check if flag exists
 			void		BroadcastEventFlagOnLogin(LPCHARACTER ch);
 
 			void		SendEventFlagList(LPCHARACTER ch);

--- a/src/game/questnpc.cpp
+++ b/src/game/questnpc.cpp
@@ -457,6 +457,22 @@ namespace quest
 			return false;
 		}
 
+		// Check if NPC quests are disabled via event flag
+		// Only blocks if flag is explicitly set to 0 (default is enabled)
+		if (m_vnum > 0)
+		{
+			string npc_flag_str = "quest_npc_" + std::to_string(m_vnum) + "_enabled";
+
+			// Only check if flag is explicitly set
+			if (CQuestManager::instance().IsEventFlagSet(npc_flag_str)
+				&& CQuestManager::instance().GetEventFlag(npc_flag_str) == 0)
+			{
+				if (test_server)
+					sys_log(0, "QUEST: NPC %u quests are disabled via event flag %s", m_vnum, npc_flag_str.c_str());
+				return false;
+			}
+		}
+
 		if (pc.IsRunning()) 
 		{
 			if (test_server)
@@ -870,7 +886,23 @@ namespace quest
 
 	bool NPC::OnChat(PC& pc)
 	{
-		if (pc.IsRunning()) 
+		// Check if NPC quests are disabled via event flag
+		// Only blocks if flag is explicitly set to 0 (default is enabled)
+		if (m_vnum > 0)
+		{
+			string npc_flag_str = "quest_npc_" + std::to_string(m_vnum) + "_enabled";
+
+			// Only check if flag is explicitly set
+			if (CQuestManager::instance().IsEventFlagSet(npc_flag_str)
+				&& CQuestManager::instance().GetEventFlag(npc_flag_str) == 0)
+			{
+				if (test_server)
+					sys_log(0, "QUEST: NPC %u chat quests are disabled via event flag %s", m_vnum, npc_flag_str.c_str());
+				return false;
+			}
+		}
+
+		if (pc.IsRunning())
 		{
 			if (test_server)
 			{


### PR DESCRIPTION
  Implemented EventFlag system to control quest availability:
  - Added IsEventFlagSet() to check if EventFlag exists in questmanager
  - Added EventFlag checks in ExecuteQuestScript() for per-quest control
  - Added EventFlag checks in HandleEvent() for NPC-based quest control
  - Added EventFlag checks in OnChat() for chat-based quest control

  Usage:
  - /event quest_<questname>_enabled 0/1 - Enable/disable specific quest
  - /event quest_npc_<vnum>_enabled 0/1 - Enable/disable all NPC quests
  - /event quests_global_enabled 0/1 - Enable/disable all quests globally