### PR TITLE
refactor(db): use std::unique_ptr for DirectQuery

### DIFF
--- a/src/db/ClientManager.cpp
+++ b/src/db/ClientManager.cpp
@@ -768,7 +768,7 @@ void CClientManager::RESULT_SAFEBOX_LOAD(CPeer * pkPeer, SQLMsg * msg)
 								pItemAward->dwVnum, pItemAward->dwCount, pItemAward->dwSocket0, pItemAward->dwSocket1, dwSocket2);
 					}
 
-					std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+					auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 					SQLResult * pRes = pmsg->Get();
 					sys_log(0, "SAFEBOX Query : [%s]", szQuery);
 
@@ -988,14 +988,14 @@ void CClientManager::QUERY_EMPIRE_SELECT(CPeer * pkPeer, DWORD dwHandle, TEmpire
 	char szQuery[QUERY_MAX_LEN];
 
 	snprintf(szQuery, sizeof(szQuery), "UPDATE player_index%s SET empire=%u WHERE id=%u", GetTablePostfix(), p->bEmpire, p->dwAccountID);
-	delete CDBManager::instance().DirectQuery(szQuery);
+	CDBManager::instance().DirectQuery(szQuery);
 
 	sys_log(0, "EmpireSelect: %s", szQuery);
 	{
 		snprintf(szQuery, sizeof(szQuery),
 				"SELECT pid1, pid2, pid3, pid4 FROM player_index%s WHERE id=%u", GetTablePostfix(), p->dwAccountID);
 
-		std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+		auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 		SQLResult * pRes = pmsg->Get();
 
@@ -1040,7 +1040,7 @@ void CClientManager::QUERY_EMPIRE_SELECT(CPeer * pkPeer, DWORD dwHandle, TEmpire
 							g_start_position[p->bEmpire][1],
 							pids[i]);
 
-					std::unique_ptr<SQLMsg> pmsg2(CDBManager::instance().DirectQuery(szQuery));
+					auto pmsg2 = CDBManager::instance().DirectQuery(szQuery);
 				}
 			}
 		}
@@ -1801,7 +1801,7 @@ void CClientManager::CreateObject(TPacketGDCreateObject * p)
 			"INSERT INTO object%s (land_id, vnum, map_index, x, y, x_rot, y_rot, z_rot) VALUES(%u, %u, %d, %d, %d, %f, %f, %f)",
 			GetTablePostfix(), p->dwLandID, p->dwVnum, p->lMapIndex, p->x, p->y, p->xRot, p->yRot, p->zRot);
 
-	std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 	if (pmsg->Get()->uiInsertID == 0)
 	{
@@ -1835,7 +1835,7 @@ void CClientManager::DeleteObject(DWORD dwID)
 
 	snprintf(szQuery, sizeof(szQuery), "DELETE FROM object%s WHERE id=%u", GetTablePostfix(), dwID);
 
-	std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 	if (pmsg->Get()->uiAffectedRows == 0 || pmsg->Get()->uiAffectedRows == (uint32_t)-1)
 	{
@@ -1889,7 +1889,8 @@ void CClientManager::BlockChat(TPacketBlockChat* p)
 		snprintf(szQuery, sizeof(szQuery), "SELECT id FROM player%s WHERE name = '%s' collate sjis_japanese_ci", GetTablePostfix(), p->szName);
 	else
 		snprintf(szQuery, sizeof(szQuery), "SELECT id FROM player%s WHERE name = '%s'", GetTablePostfix(), p->szName);
-	std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+	
+	auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 	SQLResult * pRes = pmsg->Get();
 
 	if (pRes->uiNumRows)
@@ -3037,12 +3038,11 @@ bool CClientManager::InitializeLocalization()
 {
 	char szQuery[512];	
 	snprintf(szQuery, sizeof(szQuery), "SELECT mValue, mKey FROM locale");
-	SQLMsg * pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_COMMON);
+	auto pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_COMMON);
 
 	if (pMsg->Get()->uiNumRows == 0)
 	{
 		sys_err("InitializeLocalization() ==> DirectQuery failed(%s)", szQuery);
-		delete pMsg;
 		return false;
 	}
 
@@ -3422,8 +3422,6 @@ bool CClientManager::InitializeLocalization()
 		m_vec_Locale.push_back(locale);
 	}	
 
-	delete pMsg;
-
 	return true;
 }
 //END_BOOT_LOCALIZATION
@@ -3437,12 +3435,11 @@ bool CClientManager::__GetAdminInfo(const char *szIP, std::vector<tAdminInfo> & 
 			"SELECT mID,mAccount,mName,mContactIP,mServerIP,mAuthority FROM gmlist WHERE mServerIP='ALL' or mServerIP='%s'",
 		   	szIP ? szIP : "ALL");
 
-	SQLMsg * pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_COMMON);
+	auto pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_COMMON);
 
 	if (pMsg->Get()->uiNumRows == 0)
 	{
 		sys_err("__GetAdminInfo() ==> DirectQuery failed(%s)", szQuery);
-		delete pMsg;
 		return false;
 	}
 
@@ -3480,8 +3477,6 @@ bool CClientManager::__GetAdminInfo(const char *szIP, std::vector<tAdminInfo> & 
 			   	Info.m_ID, Info.m_szAccount, Info.m_szName, Info.m_szContactIP, Info.m_szServerIP, Info.m_Authority, stAuth.c_str());
 	}
 
-	delete pMsg;
-
 	return true;
 }
 
@@ -3489,12 +3484,11 @@ bool CClientManager::__GetHostInfo(std::vector<std::string> & rIPVec)
 {
 	char szQuery[512];
 	snprintf(szQuery, sizeof(szQuery), "SELECT mIP FROM gmhost");
-	SQLMsg * pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_COMMON);
+	auto pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_COMMON);
 
 	if (pMsg->Get()->uiNumRows == 0)
 	{
 		sys_err("__GetHostInfo() ==> DirectQuery failed(%s)", szQuery);
-		delete pMsg;
 		return false;
 	}
 
@@ -3511,7 +3505,6 @@ bool CClientManager::__GetHostInfo(std::vector<std::string> & rIPVec)
 		}
 	}
 
-	delete pMsg;
 	return true;
 }
 //END_ADMIN_MANAGER
@@ -3913,7 +3906,7 @@ void CClientManager::ChangeMonarchLord(CPeer * peer, DWORD dwHandle, TPacketChan
 			GetTablePostfix(), GetTablePostfix(), info->dwPID, info->bEmpire,
 		   	info->dwPID, info->dwPID, info->dwPID, info->dwPID);
 
-	SQLMsg * pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
+	auto pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
 
 	if (pMsg->Get()->uiNumRows != 0)
 	{
@@ -3926,7 +3919,7 @@ void CClientManager::ChangeMonarchLord(CPeer * peer, DWORD dwHandle, TPacketChan
 		strlcpy(ack.szDate, row[1], sizeof(ack.szDate));
 		
 		snprintf(szQuery, sizeof(szQuery), "UPDATE monarch SET pid=%u, windate=NOW() WHERE empire=%d", ack.dwPID, ack.bEmpire);
-		SQLMsg* pMsg2 = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
+		auto pMsg2 = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
 
 		if (pMsg2->Get()->uiAffectedRows > 0)
 		{
@@ -3945,11 +3938,7 @@ void CClientManager::ChangeMonarchLord(CPeer * peer, DWORD dwHandle, TPacketChan
 				client->Encode(newInfo, sizeof(TMonarchInfo));
 			}
 		}
-
-		delete pMsg2;
 	}
-
-	delete pMsg;
 }
 
 void CClientManager::SendSpareItemIDRange(CPeer* peer)

--- a/src/db/ClientManagerBoot.cpp
+++ b/src/db/ClientManagerBoot.cpp
@@ -110,7 +110,7 @@ bool CClientManager::InitializeRefineTable()
 			"SELECT id, cost, prob, vnum0, count0, vnum1, count1, vnum2, count2,  vnum3, count3, vnum4, count4 FROM refine_proto%s",
 			GetTablePostfix());
 
-	std::unique_ptr<SQLMsg> pkMsg(CDBManager::instance().DirectQuery(query));
+	auto pkMsg = CDBManager::instance().DirectQuery(query);
 	SQLResult * pRes = pkMsg->Get();
 
 	if (!pRes->uiNumRows)
@@ -448,7 +448,7 @@ bool CClientManager::InitializeShopTable()
 		"FROM shop LEFT JOIN shop_item "
 		"ON shop.vnum = shop_item.shop_vnum ORDER BY shop.vnum, shop_item.item_vnum";
 
-	std::unique_ptr<SQLMsg> pkMsg2(CDBManager::instance().DirectQuery(s_szQuery));
+	auto pkMsg2 = CDBManager::instance().DirectQuery(s_szQuery);
 
 	// shop의 vnum은 있는데 shop_item 이 없을경우... 실패로 처리되니 주의 요망.
 	// 고처야할부분
@@ -527,7 +527,7 @@ bool CClientManager::InitializeQuestItemTable()
 	char query[1024];
 	snprintf(query, sizeof(query), s_szQuery, g_stLocaleNameColumn.c_str());
 
-	std::unique_ptr<SQLMsg> pkMsg(CDBManager::instance().DirectQuery(query));
+	auto pkMsg = CDBManager::instance().DirectQuery(query);
 	SQLResult * pRes = pkMsg->Get();
 
 	if (!pRes->uiNumRows)
@@ -863,7 +863,7 @@ bool CClientManager::InitializeSkillTable()
 		"FROM skill_proto%s ORDER BY dwVnum",
 		GetTablePostfix());
 
-	std::unique_ptr<SQLMsg> pkMsg(CDBManager::instance().DirectQuery(query));
+	auto pkMsg = CDBManager::instance().DirectQuery(query);
 	SQLResult * pRes = pkMsg->Get();
 
 	if (!pRes->uiNumRows)
@@ -944,7 +944,7 @@ bool CClientManager::InitializeBanwordTable()
 {
 	m_vec_banwordTable.clear();
 
-	std::unique_ptr<SQLMsg> pkMsg(CDBManager::instance().DirectQuery("SELECT word FROM banword"));
+	auto pkMsg = CDBManager::instance().DirectQuery("SELECT word FROM banword");
 
 	SQLResult * pRes = pkMsg->Get();
 
@@ -975,7 +975,7 @@ bool CClientManager::InitializeItemAttrTable()
 			"SELECT apply, apply+0, prob, lv1, lv2, lv3, lv4, lv5, weapon, body, wrist, foots, neck, head, shield, ear FROM item_attr%s ORDER BY apply",
 			GetTablePostfix());
 
-	std::unique_ptr<SQLMsg> pkMsg(CDBManager::instance().DirectQuery(query));
+	auto pkMsg = CDBManager::instance().DirectQuery(query);
 	SQLResult * pRes = pkMsg->Get();
 
 	if (!pRes->uiNumRows)
@@ -1049,7 +1049,7 @@ bool CClientManager::InitializeItemRareTable()
 			"SELECT apply, apply+0, prob, lv1, lv2, lv3, lv4, lv5, weapon, body, wrist, foots, neck, head, shield, ear FROM item_attr_rare%s ORDER BY apply",
 			GetTablePostfix());
 
-	std::unique_ptr<SQLMsg> pkMsg(CDBManager::instance().DirectQuery(query));
+	auto pkMsg = CDBManager::instance().DirectQuery(query);
 	SQLResult * pRes = pkMsg->Get();
 
 	if (!pRes->uiNumRows)
@@ -1127,7 +1127,7 @@ bool CClientManager::InitializeLandTable()
 		"FROM land%s WHERE enable='YES' ORDER BY id",
 		GetTablePostfix());
 
-	std::unique_ptr<SQLMsg> pkMsg(CDBManager::instance().DirectQuery(query));
+	auto pkMsg = CDBManager::instance().DirectQuery(query);
 	SQLResult * pRes = pkMsg->Get();
 
 	if (!m_vec_kLandTable.empty())
@@ -1230,7 +1230,7 @@ bool CClientManager::InitializeObjectProto()
 			"FROM object_proto%s ORDER BY vnum",
 			GetTablePostfix());
 
-	std::unique_ptr<SQLMsg> pkMsg(CDBManager::instance().DirectQuery(query));
+	auto pkMsg = CDBManager::instance().DirectQuery(query);
 	SQLResult * pRes = pkMsg->Get();
 
 	if (!m_vec_kObjectProto.empty())
@@ -1299,7 +1299,7 @@ bool CClientManager::InitializeObjectTable()
 	char query[4096];
 	snprintf(query, sizeof(query), "SELECT id, land_id, vnum, map_index, x, y, x_rot, y_rot, z_rot, life FROM object%s ORDER BY id", GetTablePostfix());
 
-	std::unique_ptr<SQLMsg> pkMsg(CDBManager::instance().DirectQuery(query));
+	auto pkMsg = CDBManager::instance().DirectQuery(query);
 	SQLResult * pRes = pkMsg->Get();
 
 	if (!m_map_pkObjectTable.empty())

--- a/src/db/ClientManagerEventFlag.cpp
+++ b/src/db/ClientManagerEventFlag.cpp
@@ -10,7 +10,7 @@ void CClientManager::LoadEventFlag()
 {
 	char szQuery[1024];
 	snprintf(szQuery, sizeof(szQuery), "SELECT szName, lValue FROM quest%s WHERE dwPID = 0", GetTablePostfix());
-	std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 	SQLResult* pRes = pmsg->Get();
 	if (pRes->uiNumRows)

--- a/src/db/ClientManagerGuild.cpp
+++ b/src/db/ClientManagerGuild.cpp
@@ -33,12 +33,12 @@ void CClientManager::GuildAddMember(CPeer* peer, TPacketGDGuildAddMember * p)
 			"INSERT INTO guild_member%s VALUES(%u, %u, %d, 0, 0)",
 			GetTablePostfix(), p->dwPID, p->dwGuild, p->bGrade);
 
-	std::unique_ptr<SQLMsg> pmsg_insert(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg_insert = CDBManager::instance().DirectQuery(szQuery);
 
 	snprintf(szQuery, sizeof(szQuery), 
 			"SELECT pid, grade, is_general, offer, level, job, name FROM guild_member%s, player%s WHERE guild_id = %u and pid = id and pid = %u", GetTablePostfix(), GetTablePostfix(), p->dwGuild, p->dwPID);
 
-	std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 	if (pmsg->Get()->uiNumRows == 0)
 	{

--- a/src/db/ClientManagerHorseName.cpp
+++ b/src/db/ClientManagerHorseName.cpp
@@ -8,7 +8,7 @@ void CClientManager::UpdateHorseName(TPacketUpdateHorseName* data, CPeer* peer)
 
 	snprintf(szQuery, sizeof(szQuery), "REPLACE INTO horse_name VALUES(%u, '%s')", data->dwPlayerID, data->szHorseName);
 
-	std::unique_ptr<SQLMsg> pmsg_insert(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg_insert = CDBManager::instance().DirectQuery(szQuery);
 
 	ForwardPacket(HEADER_DG_UPDATE_HORSE_NAME, data, sizeof(TPacketUpdateHorseName), 0, peer);
 }
@@ -19,7 +19,7 @@ void CClientManager::AckHorseName(DWORD dwPID, CPeer* peer)
 
 	snprintf(szQuery, sizeof(szQuery), "SELECT name FROM horse_name WHERE id = %u", dwPID);
 
-	std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 	TPacketUpdateHorseName packet;
 	packet.dwPlayerID = dwPID;

--- a/src/db/ClientManagerLogin.cpp
+++ b/src/db/ClientManagerLogin.cpp
@@ -161,7 +161,7 @@ void CClientManager::RESULT_LOGIN_BY_KEY(CPeer * peer, SQLMsg * msg)
 		DWORD account_id = info->pAccountTable->id;
 		char szQuery[QUERY_MAX_LEN];
 		snprintf(szQuery, sizeof(szQuery), "SELECT pid1, pid2, pid3, pid4, empire FROM player_index%s WHERE id=%u", GetTablePostfix(), account_id);
-		std::unique_ptr<SQLMsg> pMsg(CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER));
+		auto pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
 		
 		sys_log(0, "RESULT_LOGIN_BY_KEY FAIL player_index's NULL : ID:%d", account_id);
 
@@ -487,7 +487,7 @@ void CClientManager::QUERY_CHANGE_NAME(CPeer * peer, DWORD dwHandle, TPacketGDCh
 		snprintf(queryStr, sizeof(queryStr),
 			"SELECT COUNT(*) as count FROM player%s WHERE name='%s' AND id <> %u", GetTablePostfix(), p->name, p->pid);
 
-	std::unique_ptr<SQLMsg> pMsg(CDBManager::instance().DirectQuery(queryStr, SQL_PLAYER));
+	auto pMsg = CDBManager::instance().DirectQuery(queryStr, SQL_PLAYER);
 
 	if (pMsg->Get()->uiNumRows)
 	{
@@ -514,7 +514,7 @@ void CClientManager::QUERY_CHANGE_NAME(CPeer * peer, DWORD dwHandle, TPacketGDCh
 	snprintf(queryStr, sizeof(queryStr),
 			"UPDATE player%s SET name='%s',change_name=0 WHERE id=%u", GetTablePostfix(), p->name, p->pid);
 
-	std::unique_ptr<SQLMsg> pMsg0(CDBManager::instance().DirectQuery(queryStr, SQL_PLAYER));
+	auto pMsg0 = CDBManager::instance().DirectQuery(queryStr, SQL_PLAYER);
 
 	TPacketDGChangeName pdg;
 	peer->EncodeHeader(HEADER_DG_CHANGE_NAME, dwHandle, sizeof(TPacketDGChangeName));

--- a/src/db/ClientManagerPlayer.cpp
+++ b/src/db/ClientManagerPlayer.cpp
@@ -820,7 +820,7 @@ void CClientManager::__QUERY_PLAYER_CREATE(CPeer *peer, DWORD dwHandle, TPlayerC
 	queryLen = snprintf(queryStr, sizeof(queryStr), 
 			"SELECT pid%u FROM player_index%s WHERE id=%d", packet->account_index + 1, GetTablePostfix(), packet->account_id);
 
-	std::unique_ptr<SQLMsg> pMsg0(CDBManager::instance().DirectQuery(queryStr));
+	auto pMsg0 = CDBManager::instance().DirectQuery(queryStr);
 
 	if (pMsg0->Get()->uiNumRows != 0)
 	{
@@ -854,7 +854,7 @@ void CClientManager::__QUERY_PLAYER_CREATE(CPeer *peer, DWORD dwHandle, TPlayerC
 	snprintf(queryStr, sizeof(queryStr), 
 			"SELECT COUNT(*) as count FROM player%s WHERE name='%s'", GetTablePostfix(), packet->player_table.name);
 
-	std::unique_ptr<SQLMsg> pMsg1(CDBManager::instance().DirectQuery(queryStr));
+	auto pMsg1 = CDBManager::instance().DirectQuery(queryStr);
 
 	if (pMsg1->Get()->uiNumRows)
 	{
@@ -912,7 +912,7 @@ void CClientManager::__QUERY_PLAYER_CREATE(CPeer *peer, DWORD dwHandle, TPlayerC
 	CDBManager::instance().EscapeString(text, packet->player_table.quickslot, sizeof(packet->player_table.quickslot));
 	queryLen += snprintf(queryStr + queryLen, sizeof(queryStr) - queryLen, "'%s')", text);
 
-	std::unique_ptr<SQLMsg> pMsg2(CDBManager::instance().DirectQuery(queryStr));
+	auto pMsg2 = CDBManager::instance().DirectQuery(queryStr);
 	if (g_test_server)
 		sys_log(0, "Create_Player queryLen[%d] TEXT[%s]", queryLen, text);
 
@@ -927,7 +927,7 @@ void CClientManager::__QUERY_PLAYER_CREATE(CPeer *peer, DWORD dwHandle, TPlayerC
 
 	snprintf(queryStr, sizeof(queryStr), "UPDATE player_index%s SET pid%d=%d WHERE id=%d", 
 			GetTablePostfix(), packet->account_index + 1, player_id, packet->account_id);
-	std::unique_ptr<SQLMsg> pMsg3(CDBManager::instance().DirectQuery(queryStr));
+	auto pMsg3 = CDBManager::instance().DirectQuery(queryStr);
 
 	if (pMsg3->Get()->uiAffectedRows <= 0)
 	{
@@ -1074,7 +1074,7 @@ void CClientManager::__RESULT_PLAYER_DELETE(CPeer *peer, SQLMsg* msg)
 
 		snprintf(queryStr, sizeof(queryStr), "INSERT INTO player%s_deleted SELECT * FROM player%s WHERE id=%d", 
 				GetTablePostfix(), GetTablePostfix(), pi->player_id);
-		std::unique_ptr<SQLMsg> pIns(CDBManager::instance().DirectQuery(queryStr));
+		auto pIns = CDBManager::instance().DirectQuery(queryStr);
 
 		if (pIns->Get()->uiAffectedRows == 0 || pIns->Get()->uiAffectedRows == (uint32_t)-1)
 		{
@@ -1126,7 +1126,7 @@ void CClientManager::__RESULT_PLAYER_DELETE(CPeer *peer, SQLMsg* msg)
 				pi->account_index + 1, 
 				pi->player_id);
 
-		std::unique_ptr<SQLMsg> pMsg(CDBManager::instance().DirectQuery(queryStr));
+		auto pMsg = CDBManager::instance().DirectQuery(queryStr);
 
 		if (pMsg->Get()->uiAffectedRows == 0 || pMsg->Get()->uiAffectedRows == (uint32_t)-1)
 		{
@@ -1137,10 +1137,10 @@ void CClientManager::__RESULT_PLAYER_DELETE(CPeer *peer, SQLMsg* msg)
 		}
 
 		snprintf(queryStr, sizeof(queryStr), "DELETE FROM player%s WHERE id=%d", GetTablePostfix(), pi->player_id);
-		delete CDBManager::instance().DirectQuery(queryStr);
+		CDBManager::instance().DirectQuery(queryStr);
 
 		snprintf(queryStr, sizeof(queryStr), "DELETE FROM item%s WHERE owner_id=%d AND (window < %d or window = %d)", GetTablePostfix(), pi->player_id, SAFEBOX, DRAGON_SOUL_INVENTORY);
-		delete CDBManager::instance().DirectQuery(queryStr);
+		CDBManager::instance().DirectQuery(queryStr);
 
 		snprintf(queryStr, sizeof(queryStr), "DELETE FROM quest%s WHERE dwPID=%d", GetTablePostfix(), pi->player_id);
 		CDBManager::instance().AsyncQuery(queryStr);

--- a/src/db/DBManager.cpp
+++ b/src/db/DBManager.cpp
@@ -18,9 +18,9 @@ void CDBManager::Initialize()
 {
 	for (int i = 0; i < SQL_MAX_NUM; ++i)
 	{
-		m_mainSQL[i] = NULL;
-		m_directSQL[i] = NULL;
-		m_asyncSQL[i] = NULL;
+		m_mainSQL[i].reset();
+		m_directSQL[i].reset();
+		m_asyncSQL[i].reset();
 	}
 }
 
@@ -33,23 +33,9 @@ void CDBManager::Clear()
 {
 	for (int i = 0; i < SQL_MAX_NUM; ++i)
 	{
-		if (m_mainSQL[i])
-		{
-			delete m_mainSQL[i];
-			m_mainSQL[i] = NULL;
-		}
-
-		if (m_directSQL[i])
-		{
-			delete m_directSQL[i];
-			m_directSQL[i] = NULL;
-		}
-
-		if (m_asyncSQL[i])
-		{
-			delete m_asyncSQL[i];
-			m_asyncSQL[i] = NULL;
-		}
+		m_mainSQL[i].reset();
+		m_directSQL[i].reset();
+		m_asyncSQL[i].reset();
 	}
 
 	Initialize();
@@ -99,7 +85,7 @@ int CDBManager::Connect(int iSlot, const char * db_address, const int db_port, c
 		return false;
 
 	sys_log(0, "CREATING DIRECT_SQL");
-	m_directSQL[iSlot] = new CAsyncSQL2;
+	m_directSQL[iSlot] = std::make_unique<CAsyncSQL2>();
 	if (!m_directSQL[iSlot]->Setup(db_address, user, pwd, db_name, g_stLocale.c_str(), true, db_port))
 	{
 		Clear();
@@ -108,7 +94,7 @@ int CDBManager::Connect(int iSlot, const char * db_address, const int db_port, c
 
 
 	sys_log(0, "CREATING MAIN_SQL");
-	m_mainSQL[iSlot] = new CAsyncSQL2;
+	m_mainSQL[iSlot] = std::make_unique<CAsyncSQL2>();
 	if (!m_mainSQL[iSlot]->Setup(db_address, user, pwd, db_name, g_stLocale.c_str(), false, db_port))
 	{
 		Clear();
@@ -116,7 +102,7 @@ int CDBManager::Connect(int iSlot, const char * db_address, const int db_port, c
 	}
 
 	sys_log(0, "CREATING ASYNC_SQL");
-	m_asyncSQL[iSlot] = new CAsyncSQL2;
+	m_asyncSQL[iSlot] = std::make_unique<CAsyncSQL2>();
 	if (!m_asyncSQL[iSlot]->Setup(db_address, user, pwd, db_name, g_stLocale.c_str(), false, db_port))
 	{
 		Clear();
@@ -126,20 +112,20 @@ int CDBManager::Connect(int iSlot, const char * db_address, const int db_port, c
 	return true;
 }
 
-SQLMsg * CDBManager::DirectQuery(const char * c_pszQuery, int iSlot)
+std::unique_ptr<SQLMsg> CDBManager::DirectQuery(const char* c_pszQuery, int iSlot)
 {
 	//return m_directSQL[iSlot]->DirectQuery(c_pszQuery);
 
 	// DirectQuery LPHeart debuging trace 15/11/2015 06:38AM GMT
 	DWORD t = get_dword_time();
-	SQLMsg* p = m_directSQL[iSlot]->DirectQuery(c_pszQuery);
+	auto msg = m_directSQL[iSlot]->DirectQuery(c_pszQuery);
 	DWORD dt = get_dword_time() - t;
 
 	if (dt > 200) {
 		sys_err("[SLOW-DB] DirectQuery(%d) took %u ms: %s", iSlot, dt, c_pszQuery);
 	}
 
-	return p;
+	return msg;
 }
 
 extern CPacketInfo g_query_info;

--- a/src/db/DBManager.h
+++ b/src/db/DBManager.h
@@ -42,7 +42,7 @@ class CDBManager : public singleton<CDBManager>
 
 	void			ReturnQuery(const char * c_pszQuery, int iType, IDENT dwIdent, void * pvData, int iSlot = SQL_PLAYER);
 	void			AsyncQuery(const char * c_pszQuery, int iSlot = SQL_PLAYER);
-	SQLMsg *		DirectQuery(const char * c_pszQuery, int iSlot = SQL_PLAYER);
+	std::unique_ptr<SQLMsg> DirectQuery(const char* c_pszQuery, int iSlot = SQL_PLAYER);
 
 	SQLMsg *		PopResult();
 	SQLMsg * 		PopResult(eSQL_SLOT slot );
@@ -78,9 +78,9 @@ class CDBManager : public singleton<CDBManager>
 	}
 
     private:
-	CAsyncSQL2 *		m_mainSQL[SQL_MAX_NUM];
-	CAsyncSQL2 *	 	m_directSQL[SQL_MAX_NUM];
-	CAsyncSQL2 *		m_asyncSQL[SQL_MAX_NUM];
+		std::unique_ptr<CAsyncSQL2>		m_mainSQL[SQL_MAX_NUM];
+		std::unique_ptr<CAsyncSQL2>	 	m_directSQL[SQL_MAX_NUM];
+		std::unique_ptr<CAsyncSQL2>		m_asyncSQL[SQL_MAX_NUM];
 
 	int			m_quit;		// looping flag
 

--- a/src/db/GuildManager.cpp
+++ b/src/db/GuildManager.cpp
@@ -159,7 +159,7 @@ void CGuildManager::Initialize()
 {
 	char szQuery[1024];
 	snprintf(szQuery, sizeof(szQuery), "SELECT id, name, ladder_point, win, draw, loss, gold, level FROM guild%s", GetTablePostfix());
-	std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 	if (pmsg->Get()->uiNumRows)
 		ParseResult(pmsg->Get());
@@ -190,7 +190,7 @@ void CGuildManager::Load(DWORD dwGuildID)
 	char szQuery[1024];
 
 	snprintf(szQuery, sizeof(szQuery), "SELECT id, name, ladder_point, win, draw, loss, gold, level FROM guild%s WHERE id=%u", GetTablePostfix(), dwGuildID);
-	std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 	if (pmsg->Get()->uiNumRows)
 		ParseResult(pmsg->Get());
@@ -901,7 +901,7 @@ void CGuildManager::BootReserveWar()
 
 	for (int i = 0; i < 2; ++i)
 	{
-		std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(c_apszQuery[i]));
+		auto pmsg = CDBManager::instance().DirectQuery(c_apszQuery[i]);
 
 		if (pmsg->Get()->uiNumRows == 0)
 			continue;
@@ -962,7 +962,7 @@ int GetAverageGuildMemberLevel(DWORD dwGID)
 			"SELECT AVG(level) FROM guild_member%s, player%s AS p WHERE guild_id=%u AND guild_member%s.pid=p.id", 
 			GetTablePostfix(), GetTablePostfix(), dwGID, GetTablePostfix());
 
-	std::unique_ptr<SQLMsg> msg(CDBManager::instance().DirectQuery(szQuery));
+	auto msg = CDBManager::instance().DirectQuery(szQuery);
 
 	MYSQL_ROW row;
 	row = mysql_fetch_row(msg->Get()->pSQLResult);
@@ -977,7 +977,7 @@ int GetGuildMemberCount(DWORD dwGID)
 
 	snprintf(szQuery, sizeof(szQuery), "SELECT COUNT(*) FROM guild_member%s WHERE guild_id=%u", GetTablePostfix(), dwGID);
 
-	std::unique_ptr<SQLMsg> msg(CDBManager::instance().DirectQuery(szQuery));
+	auto msg = CDBManager::instance().DirectQuery(szQuery);
 
 	MYSQL_ROW row;
 	row = mysql_fetch_row(msg->Get()->pSQLResult);
@@ -1065,7 +1065,7 @@ bool CGuildManager::ReserveWar(TPacketGuildWar * p)
 			"VALUES(%u, %u, DATE_ADD(NOW(), INTERVAL 180 SECOND), %u, %ld, %ld, %ld, %ld, %ld)",
 			GID1, GID2, p->bType, static_cast<long>(p->lWarPrice), static_cast<long>(p->lInitialScore), static_cast<long>(t.lPowerFrom), static_cast<long>(t.lPowerTo), static_cast<long>(t.lHandicap));
 
-	std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 	if (pmsg->Get()->uiAffectedRows == 0 || pmsg->Get()->uiInsertID == 0 || pmsg->Get()->uiAffectedRows == (uint32_t)-1)
 	{
@@ -1187,13 +1187,13 @@ bool CGuildManager::ChangeMaster(DWORD dwGID, DWORD dwFrom, DWORD dwTo)
 	char szQuery[1024];
 
 	snprintf(szQuery, sizeof(szQuery), "UPDATE guild%s SET master=%u WHERE id=%u", GetTablePostfix(), dwTo, dwGID);
-	delete CDBManager::instance().DirectQuery(szQuery);
+	CDBManager::instance().DirectQuery(szQuery);
 
 	snprintf(szQuery, sizeof(szQuery), "UPDATE guild_member%s SET grade=1 WHERE pid=%u", GetTablePostfix(), dwTo);
-	delete CDBManager::instance().DirectQuery(szQuery);
+	CDBManager::instance().DirectQuery(szQuery);
 
 	snprintf(szQuery, sizeof(szQuery), "UPDATE guild_member%s SET grade=15 WHERE pid=%u", GetTablePostfix(), dwFrom);
-	delete CDBManager::instance().DirectQuery(szQuery);
+	CDBManager::instance().DirectQuery(szQuery);
 
 	return true;
 }
@@ -1214,7 +1214,7 @@ void CGuildWarReserve::Initialize()
 	char szQuery[256];
 	snprintf(szQuery, sizeof(szQuery), "SELECT login, guild, gold FROM guild_war_bet WHERE war_id=%u", m_data.dwID);
 
-	std::unique_ptr<SQLMsg> msgbet(CDBManager::instance().DirectQuery(szQuery));
+	auto msgbet = CDBManager::instance().DirectQuery(szQuery);
 
 	if (msgbet->Get()->uiNumRows)
 	{
@@ -1291,7 +1291,7 @@ bool CGuildWarReserve::Bet(const char * pszLogin, DWORD dwGold, DWORD dwGuild)
 			"INSERT INTO guild_war_bet (war_id, login, gold, guild) VALUES(%u, '%s', %u, %u)",
 			m_data.dwID, pszLogin, dwGold, dwGuild);
 
-	std::unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+	auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 	if (pmsg->Get()->uiAffectedRows == 0 || pmsg->Get()->uiAffectedRows == (uint32_t)-1)
 	{

--- a/src/db/HB.cpp
+++ b/src/db/HB.cpp
@@ -19,7 +19,7 @@ bool PlayerHB::Initialize()
 	char szQuery[128];
 	snprintf(szQuery, sizeof(szQuery), "SHOW CREATE TABLE player%s", GetTablePostfix());
 
-	std::unique_ptr<SQLMsg> pMsg(CDBManager::instance().DirectQuery(szQuery));
+	auto pMsg = CDBManager::instance().DirectQuery(szQuery);
 
 	if (pMsg->Get()->uiNumRows == 0)
 		return false;
@@ -75,7 +75,7 @@ bool PlayerHB::Query(DWORD id)
 
 		snprintf(szQuery, sizeof(szQuery), "CREATE TABLE IF NOT EXISTS %s%s", szTableName, m_stCreateTableQuery.c_str() + strlen(szFind));
 	//	sys_log(0, "%s", szQuery);
-		std::unique_ptr<SQLMsg> pMsg(CDBManager::instance().DirectQuery(szQuery, SQL_HOTBACKUP));
+		auto pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_HOTBACKUP);
 		m_stTableName = szTableName;
 	}
 

--- a/src/db/ItemIDRangeManager.cpp
+++ b/src/db/ItemIDRangeManager.cpp
@@ -88,12 +88,11 @@ bool CItemIDRangeManager::BuildRange(DWORD dwMin, DWORD dwMax, TItemIDRangeTable
 {
 	char szQuery[1024];
 	DWORD dwItemMaxID = 0;
-	SQLMsg* pMsg = NULL;
 	MYSQL_ROW row;
 
 	snprintf(szQuery, sizeof(szQuery), "SELECT MAX(id) FROM item%s WHERE id >= %u and id <= %u", GetTablePostfix(), dwMin, dwMax);
 
-	pMsg = CDBManager::instance().DirectQuery(szQuery);
+	auto pMsg = CDBManager::instance().DirectQuery(szQuery);
 
 	if (pMsg != NULL)
 	{
@@ -102,7 +101,6 @@ bool CItemIDRangeManager::BuildRange(DWORD dwMin, DWORD dwMax, TItemIDRangeTable
 			row = mysql_fetch_row(pMsg->Get()->pSQLResult);
 			str_to_number(dwItemMaxID, row[0]);
 		}
-		delete pMsg;
 	}
 
 	if (dwItemMaxID == 0)
@@ -124,14 +122,14 @@ bool CItemIDRangeManager::BuildRange(DWORD dwMin, DWORD dwMax, TItemIDRangeTable
 		snprintf(szQuery, sizeof(szQuery), "SELECT COUNT(*) FROM item%s WHERE id >= %u AND id <= %u", 
 				GetTablePostfix(), range.dwUsableItemIDMin, range.dwMax);
 
-		pMsg = CDBManager::instance().DirectQuery(szQuery);
+		auto pMsg2 = CDBManager::instance().DirectQuery(szQuery);
 
-		if (pMsg != NULL)
+		if (pMsg2 != NULL)
 		{
-			if (pMsg->Get()->uiNumRows > 0)
+			if (pMsg2->Get()->uiNumRows > 0)
 			{
 				DWORD count = 0;
-				row = mysql_fetch_row(pMsg->Get()->pSQLResult);
+				row = mysql_fetch_row(pMsg2->Get()->pSQLResult);
 				str_to_number(count, row[0]);
 
 				if (count > 0)
@@ -145,8 +143,6 @@ bool CItemIDRangeManager::BuildRange(DWORD dwMin, DWORD dwMax, TItemIDRangeTable
 					return true;
 				}
 			}
-
-			delete pMsg;
 		}
 	}
 

--- a/src/db/Marriage.cpp
+++ b/src/db/Marriage.cpp
@@ -40,9 +40,9 @@ namespace marriage
 				"SELECT pid1, pid2, love_point, time, is_married, p1.name, p2.name FROM marriage, player%s as p1, player%s as p2 WHERE p1.id = pid1 AND p2.id = pid2",
 				GetTablePostfix(), GetTablePostfix());
 
-		unique_ptr<SQLMsg> pmsg_delete(CDBManager::instance().DirectQuery("DELETE FROM marriage WHERE is_married = 0"));
-		unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
-
+		CDBManager::instance().DirectQuery("DELETE FROM marriage WHERE is_married = 0");
+		
+		auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 		SQLResult * pRes = pmsg->Get();
 		sys_log(0, "MarriageList(size=%lu)", pRes->uiNumRows);
 
@@ -101,7 +101,7 @@ namespace marriage
 		char szQuery[512];
 		snprintf(szQuery, sizeof(szQuery), "INSERT INTO marriage(pid1, pid2, love_point, time) VALUES (%u, %u, 0, %u)", dwPID1, dwPID2, now);
 
-		unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+		auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 		SQLResult* res = pmsg->Get();
 		if (res->uiAffectedRows == 0 || res->uiAffectedRows == (uint32_t)-1)
@@ -141,7 +141,7 @@ namespace marriage
 		snprintf(szQuery, sizeof(szQuery), "UPDATE marriage SET love_point = %d, is_married = %d WHERE pid1 = %u AND pid2 = %u", 
 				iLovePoint, byMarried, pMarriage->pid1, pMarriage->pid2);
 
-		unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+		auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 		SQLResult* res = pmsg->Get();
 		if (res->uiAffectedRows == 0 || res->uiAffectedRows == (uint32_t)-1)
@@ -187,7 +187,7 @@ namespace marriage
 		char szQuery[512];
 		snprintf(szQuery, sizeof(szQuery), "DELETE FROM marriage WHERE pid1 = %u AND pid2 = %u", dwPID1, dwPID2);
 
-		unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+		auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 		SQLResult* res = pmsg->Get();
 		if (res->uiAffectedRows == 0 || res->uiAffectedRows == (uint32_t)-1)
@@ -231,7 +231,7 @@ namespace marriage
 		snprintf(szQuery, sizeof(szQuery), "UPDATE marriage SET is_married = 1 WHERE pid1 = %u AND pid2 = %u", 
 				pMarriage->pid1, pMarriage->pid2);
 
-		unique_ptr<SQLMsg> pmsg(CDBManager::instance().DirectQuery(szQuery));
+		auto pmsg = CDBManager::instance().DirectQuery(szQuery);
 
 		SQLResult* res = pmsg->Get();
 		if (res->uiAffectedRows == 0 || res->uiAffectedRows == (uint32_t)-1)

--- a/src/db/Monarch.cpp
+++ b/src/db/Monarch.cpp
@@ -177,11 +177,10 @@ bool CMonarch::LoadMonarch()
 	MonarchInfo * p = &m_MonarchInfo;
     char szQuery[256];
 	snprintf(szQuery, sizeof(szQuery), "SELECT empire, pid, name, money, windate FROM monarch a, player%s b where a.pid=b.id", GetTablePostfix());
-    SQLMsg * pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
+    auto pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
 
     if (pMsg->Get()->uiNumRows == 0)
     {
-        delete pMsg;
         return false;
     }
 
@@ -201,7 +200,6 @@ bool CMonarch::LoadMonarch()
         	sys_log(0, "[LOAD_MONARCH] Empire %d pid %d money %lld windate %s", Empire, p->pid[Empire], static_cast<long long>(p->money[Empire]), p->date[Empire]);
     }
 
-    delete pMsg;
     return true;
 }
 
@@ -211,11 +209,10 @@ bool CMonarch::SetMonarch(const char * name)
     char szQuery[256];
 
 	snprintf(szQuery, sizeof(szQuery), "SELECT empire, pid, name FROM player a where a.name = '%s'", name);
-    SQLMsg * pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
+    auto pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
 
     if (pMsg->Get()->uiNumRows == 0)
     {
-        delete pMsg;
         return false;
     }
 
@@ -233,7 +230,6 @@ bool CMonarch::SetMonarch(const char * name)
 		if (g_test_server)
 			sys_log(0, "[Set_MONARCH] Empire %d pid %d money %lld windate %s", Empire, p->pid[Empire], static_cast<long long>(p->money[Empire]), p->date[Empire]);
     }
-    delete pMsg;
 
 	//db¿¡ ÀÔ·Â
 	snprintf(szQuery, sizeof(szQuery),
@@ -248,15 +244,11 @@ bool CMonarch::DelMonarch(int Empire)
 	char szQuery[256];
 
 	snprintf(szQuery, sizeof(szQuery), "DELETE from monarch where empire=%d", Empire);
-	SQLMsg * pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
-
+	auto pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
 	if (pMsg->Get()->uiNumRows == 0)
 	{
-		delete pMsg;
 		return false;
 	}
-
-	delete pMsg;
 
 	memset(m_MonarchInfo.name[Empire], 0, sizeof(m_MonarchInfo.name[Empire]));
 	m_MonarchInfo.money[Empire] = 0;
@@ -274,16 +266,13 @@ bool CMonarch::DelMonarch(const char * name)
 
 			int Empire = n;
 			snprintf(szQuery, sizeof(szQuery), "DELETE from monarch where name=%d", Empire);
-			SQLMsg * pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
+			auto pMsg = CDBManager::instance().DirectQuery(szQuery, SQL_PLAYER);
 
 			if (pMsg->Get()->uiNumRows == 0)
 			{
 				sys_err(" DirectQuery failed(%s)", szQuery);
-				delete pMsg;
 				return false;
 			}
-
-			delete pMsg;
 
 			memset(m_MonarchInfo.name[Empire], 0, 32);
 			m_MonarchInfo.money[Empire] = 0;

--- a/src/game/char_change_empire.cpp
+++ b/src/game/char_change_empire.cpp
@@ -32,7 +32,7 @@ int CHARACTER::ChangeEmpire(BYTE empire)
 				"SELECT id, pid1, pid2, pid3, pid4 FROM player_index%s WHERE pid1=%u OR pid2=%u OR pid3=%u OR pid4=%u AND empire=%u", 
 				get_table_postfix(), GetPlayerID(), GetPlayerID(), GetPlayerID(), GetPlayerID(), GetEmpire());
 
-		std::unique_ptr<SQLMsg> msg(DBManager::instance().DirectQuery(szQuery));
+		auto msg = DBManager::instance().DirectQuery(szQuery);
 
 		if (msg->Get()->uiNumRows == 0)
 		{
@@ -55,13 +55,12 @@ int CHARACTER::ChangeEmpire(BYTE empire)
 		//   한 캐릭터라도 길드에 가입 되어 있다면, 제국 이동을 할 수 없다.
 		DWORD dwGuildID[4];
 		CGuild * pGuild[4];
-		SQLMsg * pMsg = NULL;
 		
 		for (int i = 0; i < loop; ++i)
 		{
 			snprintf(szQuery, sizeof(szQuery), "SELECT guild_id FROM guild_member%s WHERE pid=%u", get_table_postfix(), dwPID[i]);
 
-			pMsg = DBManager::instance().DirectQuery(szQuery);
+			auto pMsg = DBManager::instance().DirectQuery(szQuery);
 
 			if (pMsg != NULL)
 			{
@@ -75,7 +74,6 @@ int CHARACTER::ChangeEmpire(BYTE empire)
 
 					if (pGuild[i] != NULL)
 					{
-						M2_DELETE(pMsg);
 						return 2;
 					}
 				}
@@ -84,8 +82,6 @@ int CHARACTER::ChangeEmpire(BYTE empire)
 					dwGuildID[i] = 0;
 					pGuild[i] = NULL;
 				}
-
-				M2_DELETE(pMsg);
 			}
 		}
 	}
@@ -105,7 +101,7 @@ int CHARACTER::ChangeEmpire(BYTE empire)
 		snprintf(szQuery, sizeof(szQuery), "UPDATE player_index%s SET empire=%u WHERE pid1=%u OR pid2=%u OR pid3=%u OR pid4=%u AND empire=%u", 
 				get_table_postfix(), empire, GetPlayerID(), GetPlayerID(), GetPlayerID(), GetPlayerID(), GetEmpire());
 
-		std::unique_ptr<SQLMsg> msg(DBManager::instance().DirectQuery(szQuery));
+		auto msg = DBManager::instance().DirectQuery(szQuery);
 
 		if (msg->Get()->uiAffectedRows > 0)
 		{
@@ -129,13 +125,12 @@ int CHARACTER::GetChangeEmpireCount() const
 
 	snprintf(szQuery, sizeof(szQuery), "SELECT change_count FROM change_empire WHERE account_id = %u", dwAID);
 
-	SQLMsg * pMsg = DBManager::instance().DirectQuery(szQuery);
+	auto pMsg = DBManager::instance().DirectQuery(szQuery);
 
 	if (pMsg != NULL)
 	{
 		if (pMsg->Get()->uiNumRows == 0)
 		{
-			M2_DELETE(pMsg);
 			return 0;
 		}
 
@@ -143,8 +138,6 @@ int CHARACTER::GetChangeEmpireCount() const
 
 		DWORD count = 0;
 		str_to_number(count, row[0]);
-
-		M2_DELETE(pMsg);
 
 		return count;
 	}
@@ -173,7 +166,7 @@ void CHARACTER::SetChangeEmpireCount()
 		snprintf(szQuery, sizeof(szQuery), "UPDATE change_empire SET change_count=%d WHERE account_id=%u", count, dwAID);
 	}
 
-	std::unique_ptr<SQLMsg> pmsg(DBManager::instance().DirectQuery(szQuery));
+	DBManager::instance().DirectQuery(szQuery);
 }
 
 DWORD CHARACTER::GetAID() const
@@ -184,21 +177,16 @@ DWORD CHARACTER::GetAID() const
 	snprintf(szQuery, sizeof(szQuery), "SELECT id FROM player_index%s WHERE pid1=%u OR pid2=%u OR pid3=%u OR pid4=%u AND empire=%u", 
 			get_table_postfix(), GetPlayerID(), GetPlayerID(), GetPlayerID(), GetPlayerID(), GetEmpire());
 
-	SQLMsg* pMsg = DBManager::instance().DirectQuery(szQuery);
+	auto pMsg = DBManager::instance().DirectQuery(szQuery);
 
-	if (pMsg != NULL)
+	if (pMsg)
 	{
 		if (pMsg->Get()->uiNumRows == 0)
-		{
-			M2_DELETE(pMsg);
 			return 0;
-		}
 
 		MYSQL_ROW row = mysql_fetch_row(pMsg->Get()->pSQLResult);
 
 		str_to_number(dwAID, row[0]);
-
-		M2_DELETE(pMsg);
 
 		return dwAID;
 	}

--- a/src/game/config.cpp
+++ b/src/game/config.cpp
@@ -882,7 +882,7 @@ void config_init(const string& st_localeServiceName)
 		char szQuery[512];
 		snprintf(szQuery, sizeof(szQuery), "SELECT mKey, mValue FROM locale");
 
-		std::unique_ptr<SQLMsg> pMsg(AccountDB::instance().DirectQuery(szQuery));
+		auto pMsg = AccountDB::instance().DirectQuery(szQuery);
 
 		if (pMsg->Get()->uiNumRows == 0)
 		{
@@ -950,7 +950,7 @@ void config_init(const string& st_localeServiceName)
 	{
 		char szQuery[256];
 		snprintf(szQuery, sizeof(szQuery), "SELECT mValue FROM locale WHERE mKey='SKILL_POWER_BY_LEVEL'");
-		std::unique_ptr<SQLMsg> pMsg(AccountDB::instance().DirectQuery(szQuery));
+		auto pMsg = AccountDB::instance().DirectQuery(szQuery);
 
 		if (pMsg->Get()->uiNumRows == 0)
 		{
@@ -991,7 +991,7 @@ void config_init(const string& st_localeServiceName)
 		for (int job = 0; job < JOB_MAX_NUM * 2; ++job)
 		{
 			snprintf(szQuery, sizeof(szQuery), "SELECT mValue from locale where mKey='SKILL_POWER_BY_LEVEL_TYPE%d' ORDER BY CAST(mValue AS unsigned)", job);
-			std::unique_ptr<SQLMsg> pMsg(AccountDB::instance().DirectQuery(szQuery));
+			auto pMsg = AccountDB::instance().DirectQuery(szQuery);
 
 			// 세팅이 안되어있으면 기본테이블을 사용한다.
 			if (pMsg->Get()->uiNumRows == 0)

--- a/src/game/db.cpp
+++ b/src/game/db.cpp
@@ -55,7 +55,7 @@ void DBManager::Query(const char * c_pszFormat, ...)
 	m_sql.AsyncQuery(szQuery);
 }
 
-SQLMsg * DBManager::DirectQuery(const char * c_pszFormat, ...)
+std::unique_ptr<SQLMsg> DBManager::DirectQuery(const char* c_pszFormat, ...)
 {
 	char szQuery[4096];
 	va_list args;
@@ -68,14 +68,14 @@ SQLMsg * DBManager::DirectQuery(const char * c_pszFormat, ...)
 
 	// DirectQuery LPHeart debuging trace 15/11/2015 06:38AM GMT
 	DWORD t = get_dword_time();
-	SQLMsg* p = m_sql_direct.DirectQuery(szQuery);
+	auto msg = m_sql_direct.DirectQuery(szQuery);
 	DWORD dt = get_dword_time() - t;
 
 	if (dt > 200) {
 		sys_err("[SLOW-GAME] DirectQuery took %u ms: %s", dt, szQuery);
 	}
 
-	return p;
+	return msg;
 }
 
 bool DBManager::IsConnected()
@@ -411,7 +411,7 @@ void DBManager::AnalyzeReturnQuery(SQLMsg * pMsg)
 
 							char szQuery[1024];
 							snprintf(szQuery, sizeof(szQuery), "UPDATE account SET last_play=NOW() WHERE id=%u", dwID);
-							std::unique_ptr<SQLMsg> msg( DBManager::instance().DirectQuery(szQuery) );
+							DBManager::instance().DirectQuery(szQuery);
 						}
 
 						TAccountTable & r = d->GetAccountTable();
@@ -645,7 +645,7 @@ void AccountDB::SetLocale(const std::string & stLocale)
 	m_sql_direct.QueryLocaleSet();
 }
 
-SQLMsg* AccountDB::DirectQuery(const char * query)
+std::unique_ptr<SQLMsg> AccountDB::DirectQuery(const char* query)
 {
 	return m_sql_direct.DirectQuery(query);
 }

--- a/src/game/db.h
+++ b/src/game/db.h
@@ -73,7 +73,7 @@ class DBManager : public singleton<DBManager>
 		bool			Connect(const char * host, const int port, const char * user, const char * pwd, const char * db);
 		void			Query(const char * c_pszFormat, ...);
 
-		SQLMsg *		DirectQuery(const char * c_pszFormat, ...);
+		std::unique_ptr<SQLMsg> DirectQuery(const char* c_pszFormat, ...);
 		void			ReturnQuery(int iType, DWORD dwIdent, void* pvData, const char * c_pszFormat, ...);
 
 		void			Process();
@@ -168,7 +168,7 @@ class AccountDB : public singleton<AccountDB>
 		bool Connect(const char * host, const int port, const char * user, const char * pwd, const char * db);
 		bool ConnectAsync(const char * host, const int port, const char * user, const char * pwd, const char * db, const char * locale);
 
-		SQLMsg* DirectQuery(const char * query);		
+		std::unique_ptr<SQLMsg> DirectQuery(const char* query);
 		void ReturnQuery(int iType, DWORD dwIdent, void * pvData, const char * c_pszFormat, ...);
 		void AsyncQuery(const char* query);
 

--- a/src/game/guild_manager.cpp
+++ b/src/game/guild_manager.cpp
@@ -81,8 +81,8 @@ DWORD CGuildManager::CreateGuild(TGuildCreateParameter& gcp)
 		return 0;
 	}
 
-	std::unique_ptr<SQLMsg> pmsg(DBManager::instance().DirectQuery("SELECT COUNT(*) FROM guild%s WHERE name = '%s'",
-				get_table_postfix(), gcp.name));
+	auto pmsg = DBManager::instance().DirectQuery("SELECT COUNT(*) FROM guild%s WHERE name = '%s'",
+				get_table_postfix(), gcp.name);
 
 	if (pmsg->Get()->uiNumRows > 0)
 	{
@@ -204,7 +204,7 @@ void CGuildManager::Initialize()
 		return;
 	}
 
-	std::unique_ptr<SQLMsg> pmsg(DBManager::instance().DirectQuery("SELECT id FROM guild%s", get_table_postfix()));
+	auto pmsg = DBManager::instance().DirectQuery("SELECT id FROM guild%s", get_table_postfix());
 
 	std::vector<DWORD> vecGuildID;
 	vecGuildID.reserve(pmsg->Get()->uiNumRows);

--- a/src/game/questlua_building.cpp
+++ b/src/game/questlua_building.cpp
@@ -97,7 +97,7 @@ namespace quest
 			lua_pushboolean(L, false);
 		*/
 
-		std::unique_ptr<SQLMsg> pmsg(DBManager::instance().DirectQuery("SELECT COUNT(*) FROM land%s WHERE guild_id = %d", get_table_postfix(), (DWORD)lua_tonumber(L,1)));
+		auto pmsg = DBManager::instance().DirectQuery("SELECT COUNT(*) FROM land%s WHERE guild_id = %d", get_table_postfix(), (DWORD)lua_tonumber(L,1));
 
 		if ( pmsg->Get()->uiNumRows > 0 )
 		{

--- a/src/game/questlua_pc.cpp
+++ b/src/game/questlua_pc.cpp
@@ -2097,7 +2097,7 @@ teleport_area:
 
 		char szQuery[1024];
 		snprintf(szQuery, sizeof(szQuery), "SELECT COUNT(*) FROM player%s WHERE name='%s'", get_table_postfix(), szName);
-		std::unique_ptr<SQLMsg> pmsg(DBManager::instance().DirectQuery(szQuery));
+		auto pmsg = DBManager::instance().DirectQuery(szQuery);
 
 		if ( pmsg->Get()->uiNumRows > 0 )
 		{
@@ -2126,8 +2126,7 @@ teleport_area:
 		LogManager::instance().ChangeNameLog(pid, ch->GetName(), szName, ch->GetDesc()->GetHostName());
 
 		snprintf(szQuery, sizeof(szQuery), "UPDATE player%s SET name='%s' WHERE id=%u", get_table_postfix(), szName, pid);
-		SQLMsg * msg = DBManager::instance().DirectQuery(szQuery);
-		M2_DELETE(msg);
+		DBManager::instance().DirectQuery(szQuery);
 
 		ch->SetNewName(szName);
 		lua_pushnumber(L, 4);

--- a/src/libsql/AsyncSQL.h
+++ b/src/libsql/AsyncSQL.h
@@ -8,6 +8,8 @@
 #include <queue>
 #include <vector>
 #include <map>
+#include <memory>
+
 #include <mysql.h>
 #include <errmsg.h>
 #include <mysqld_error.h>
@@ -126,7 +128,7 @@ class CAsyncSQL
 
 		void		AsyncQuery(const char * c_pszQuery);
 		void		ReturnQuery(const char * c_pszQuery, void * pvUserData);
-		SQLMsg *	DirectQuery(const char * c_pszQuery);
+		std::unique_ptr<SQLMsg>	DirectQuery(const char* c_pszQuery);
 
 		DWORD		CountQuery();
 		DWORD		CountResult();
@@ -184,12 +186,12 @@ class CAsyncSQL
 
 #ifndef OS_WINDOWS
 		pthread_t m_hThread;
-		pthread_mutex_t	* m_mtxQuery;
-		pthread_mutex_t	* m_mtxResult;
+		std::unique_ptr<pthread_mutex_t> m_mtxQuery;
+		std::unique_ptr<pthread_mutex_t> m_mtxResult;
 #else
 		HANDLE m_hThread;
-		CRITICAL_SECTION* m_mtxQuery;
-		CRITICAL_SECTION* m_mtxResult;
+		std::unique_ptr<CRITICAL_SECTION> m_mtxQuery;
+		std::unique_ptr<CRITICAL_SECTION> m_mtxResult;
 #endif
 
 		CSemaphore m_sem;


### PR DESCRIPTION
Migrated `DirectQuery` to return `std::unique_ptr<SQLMsg>`, enforcing RAII and removing manual memory management.
Updated call sites to use `auto msg = DirectQuery(...)`.
No functional changes intended.
