### PR TITLE
Add full Linux support with fdwatch using epoll

### DIFF
--- a/src/db/PeerBase.cpp
+++ b/src/db/PeerBase.cpp
@@ -62,6 +62,7 @@ bool CPeerBase::Accept(socket_t fd_accept)
 		return false;
 	}
 
+	fdwatch_insert_fd(m_fdWatcher, m_fd);
 	fdwatch_add_fd(m_fdWatcher, m_fd, this, FDW_READ, false);
 
 	OnAccept();
@@ -84,6 +85,7 @@ bool CPeerBase::Connect(const char* host, WORD port)
 		return false;
 	}
 
+	fdwatch_insert_fd(m_fdWatcher, m_fd);
 	fdwatch_add_fd(m_fdWatcher, m_fd, this, FDW_READ, false);
 
 	OnConnect();

--- a/src/game/desc_client.cpp
+++ b/src/game/desc_client.cpp
@@ -92,6 +92,7 @@ bool CLIENT_DESC::Connect(int iPhaseWhenSucceed)
 	if (m_sock != INVALID_SOCKET)
 	{
 		sys_log(0, "SYSTEM: connected to server (fd %d, ptr %p)", m_sock, this);
+		fdwatch_insert_fd(m_lpFdw, m_sock);
 		fdwatch_add_fd(m_lpFdw, m_sock, this, FDW_READ, false);
 		fdwatch_add_fd(m_lpFdw, m_sock, this, FDW_WRITE, false);
 		SetPhase(m_iPhaseWhenSucceed);

--- a/src/game/desc_p2p.cpp
+++ b/src/game/desc_p2p.cpp
@@ -40,6 +40,7 @@ bool DESC_P2P::Setup(LPFDWATCH fdw, socket_t fd, const char * host, WORD wPort)
 	if (!(m_lpInputBuffer = buffer_new(1024 * 1024)))
 		return false;
 
+	fdwatch_insert_fd(m_lpFdw, m_sock);
 	fdwatch_add_fd(m_lpFdw, m_sock, this, FDW_READ, false);
 
 	m_iMinInputBufferLen = 1024 * 1024;

--- a/src/libthecore/fdwatch.cpp
+++ b/src/libthecore/fdwatch.cpp
@@ -1,6 +1,6 @@
 ﻿#include "stdafx.h"
 
-#ifndef __USE_SELECT__
+#ifdef OS_FREEBSD
 
 LPFDWATCH fdwatch_new(int nfiles)
 {
@@ -230,7 +230,11 @@ void * fdwatch_get_client_data(LPFDWATCH fdw, unsigned int event_idx)
 
     return (fdw->fd_data[fd]);
 }
-#else	// ifndef __USE_SELECT__
+
+void fdwatch_insert_fd(LPFDWATCH fdw, socket_t fd)
+{
+}
+#endif	// ifdef OS_FREEBSD
 
 #ifdef OS_WINDOWS
 static int win32_init_refcount = 0;
@@ -258,7 +262,6 @@ static void win32_deinit()
     if (--win32_init_refcount <= 0)
 	WSACleanup();
 }
-#endif
 
 LPFDWATCH fdwatch_new(int nfiles)
 {
@@ -457,4 +460,406 @@ int fdwatch_get_buffer_size(LPFDWATCH fdw, socket_t fd)
     return INT_MAX; // XXX TODO
 }
 
+void fdwatch_insert_fd(LPFDWATCH fdw, socket_t fd)
+{
+}
+
+#endif
+
+#ifdef __linux__
+
+#include <sys/epoll.h>
+/* ---------------------------------------------------------------------- */
+/* INIT / DESTROY                                                         */
+/* ---------------------------------------------------------------------- */
+
+LPFDWATCH fdwatch_new(int nfiles) {
+  int epfd = epoll_create1(0);
+  if (epfd == -1) {
+    return nullptr;
+  }
+
+  LPFDWATCH fdw = new FDWATCH;
+  fdw->epfd = epfd;
+  fdw->nfiles = nfiles;
+
+  fdw->events = new epoll_event[nfiles]();
+  fdw->fd_registered = new bool[nfiles]();
+  fdw->fd_rw_current = new int[nfiles]();
+  fdw->fd_rw_pending = new int[nfiles]();
+  fdw->fd_pending_op = new EPendingOp[nfiles]();
+  fdw->fd_data = new void *[nfiles]();
+
+  // nuovi
+  fdw->dirty_fds = new int[nfiles]();
+  fdw->fd_dirty = new bool[nfiles]();
+  fdw->dirty_count = 0;
+
+  fdw->nevents = 0;
+
+  return fdw;
+}
+
+void fdwatch_delete(LPFDWATCH fdw) {
+  if (!fdw)
+    return;
+
+  delete[] fdw->fd_registered;
+  delete[] fdw->events;
+  delete[] fdw->fd_data;
+  delete[] fdw->fd_rw_current;
+  delete[] fdw->fd_rw_pending;
+  delete[] fdw->fd_pending_op;
+
+  delete[] fdw->dirty_fds;
+  delete[] fdw->fd_dirty;
+
+  close(fdw->epfd);
+  delete fdw;
+}
+
+static inline void fdwatch_mark_dirty(LPFDWATCH fdw, int fd) {
+  if ((fd < 0) || (fd >= fdw->nfiles))
+    return;
+
+  if (!fdw->fd_dirty[fd]) {
+    fdw->fd_dirty[fd] = true;
+    fdw->dirty_fds[fdw->dirty_count++] = fd;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+/* SYNC INTERNO: costruzione della struct epoll_event da fd_rw_pending    */
+/* (non fa syscall, solo helper)                                          */
+/* ---------------------------------------------------------------------- */
+
+static void fdwatch_build_event(LPFDWATCH fdw, socket_t fd,
+                                struct epoll_event *ev) {
+
+  // memset(ev, 0, sizeof(*ev));
+  const int mask = fdw->fd_rw_pending[fd];
+  uint32_t events = EPOLLRDHUP;
+
+  if (mask & (FDW_READ | FDW_READ_ONESHOT))
+    events |= EPOLLIN;
+  if (mask & (FDW_WRITE | FDW_WRITE_ONESHOT))
+    events |= EPOLLOUT;
+  if (mask & (FDW_READ_ONESHOT | FDW_WRITE_ONESHOT))
+    events |= EPOLLONESHOT;
+
+  ev->events = events;
+  ev->data.fd = fd;
+}
+
+/* ---------------------------------------------------------------------- */
+/* FASE DI APPLICAZIONE DELLE MODIFICHE PENDENTI PRIMA DI epoll_wait      */
+/* ---------------------------------------------------------------------- */
+
+static void fdwatch_apply_pending(LPFDWATCH fdw) {
+
+  struct epoll_event ev;
+  memset(&ev, 0, sizeof(ev));
+
+  // iteriamo solo sui fd "sporchi"
+  for (int i = 0; i < fdw->dirty_count; ++i) {
+    int fd = fdw->dirty_fds[i];
+
+    // resettiamo subito il flag di "dirty":
+    fdw->fd_dirty[fd] = false;
+
+    EPendingOp op = fdw->fd_pending_op[fd];
+
+    if (op == FDW_OP_NONE)
+      continue; // nessuna op pendente (può succedere se è stata azzerata dopo
+                // il mark)
+
+    switch (op) {
+      
+      case FDW_OP_ADD:
+        fdwatch_build_event(fdw, fd, &ev);
+        epoll_ctl(fdw->epfd, EPOLL_CTL_ADD, fd, &ev);
+        fdw->fd_registered[fd] = true;
+        break;
+      case FDW_OP_MOD:
+        fdwatch_build_event(fdw, fd, &ev);
+        epoll_ctl(fdw->epfd, EPOLL_CTL_MOD, fd, &ev);
+        break;
+      case FDW_OP_DEL:
+        epoll_ctl(fdw->epfd, EPOLL_CTL_DEL, fd, nullptr);
+        fdw->fd_registered[fd] = false;
+        break;
+    };
+
+    fdw->fd_rw_current[fd] = fdw->fd_rw_pending[fd];
+    fdw->fd_pending_op[fd] = FDW_OP_NONE;
+
+
+  }
+
+  // dopo aver processato tutti, azzeriamo il contatore
+  fdw->dirty_count = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+/* fdwatch: unica funzione che fa epoll_ctl (batch) + epoll_wait          */
+/* ---------------------------------------------------------------------- */
+
+int fdwatch(LPFDWATCH fdw, struct timeval *timeout) {
+
+  int timeout_ms;
+
+  if (!timeout) {
+    timeout_ms = 0;
+  } else {
+    timeout_ms = timeout->tv_sec * 1000 + (timeout->tv_usec + 999) / 1000;
+  }
+
+  // Applica tutte le modifiche pendenti in una volta
+  fdwatch_apply_pending(fdw);
+
+  int r;
+  do {
+    r = epoll_wait(fdw->epfd, fdw->events, fdw->nfiles, timeout_ms);
+  } while ((r == -1) && (errno == EINTR));
+
+
+  //per ogni evento, se c'è stato un oneshot, prova a riabilitare gli altri non oneshot
+  for (int event_idx = 0; event_idx < r; ++event_idx)
+  {
+    struct epoll_event &ev = fdw->events[event_idx];
+    const uint32_t events = ev.events;
+    const int fd = ev.data.fd;
+
+    if (events & (EPOLLERR | EPOLLHUP | EPOLLRDHUP))
+    {
+      fdw->fd_rw_pending[fd] = 0;
+      fdw->fd_pending_op[fd] = FDW_OP_MOD;
+      fdwatch_mark_dirty(fdw, fd);
+      continue;
+    }
+
+    
+
+    const int old_mask = fdw->fd_rw_pending[fd];
+    int new_mask = old_mask;
+
+    // EPOLLIN
+    if (events & EPOLLIN) {
+      new_mask &= ~FDW_READ_ONESHOT;
+    }
+
+    // EPOLLOUT
+    if (events & EPOLLOUT) {
+      new_mask &= ~FDW_WRITE_ONESHOT;
+    }
+
+    
+
+    if (new_mask != old_mask)
+    {
+      fdw->fd_rw_pending[fd] = new_mask;
+      fdw->fd_pending_op[fd] = FDW_OP_MOD;
+      fdwatch_mark_dirty(fdw, fd);
+    }
+
+
+  }
+
+
+  fdw->nevents = r;
+  return r;
+}
+
+/* ---------------------------------------------------------------------- */
+/* fdwatch_check_event                                                    */
+/* - Usa fd_rw_current per sapere cosa era effettivamente registrato      */
+/* - Aggiorna fd_rw_pending se togliamo i flag ONESHOT                    */
+/* - NON chiama epoll_ctl: le modifiche verranno applicate nel prossimo   */
+/*   fdwatch() tramite fdwatch_apply_pending()                             */
+/* ---------------------------------------------------------------------- */
+
+int fdwatch_check_event(LPFDWATCH fdw, int fd, unsigned int event_idx) {
+
+  struct epoll_event &ev = fdw->events[event_idx];
+
+  if (ev.data.fd != fd)
+    return 0;
+
+  const uint32_t events = ev.events;
+
+  if (events & (EPOLLERR | EPOLLHUP | EPOLLRDHUP))
+    return FDW_EOF;
+
+  //const int cur_mask = fdw->fd_rw_current[fd];
+  //const int old_mask = fdw->fd_rw_pending[fd];
+  //int new_mask = old_mask;
+
+  int result = 0;
+
+  // EPOLLIN
+  if ((events & EPOLLIN) /*&& (cur_mask & (FDW_READ | FDW_READ_ONESHOT))*/) {
+
+    //new_mask &= ~FDW_READ_ONESHOT;
+    result |= FDW_READ;
+  }
+
+  // EPOLLOUT
+  if ((events & EPOLLOUT) /*&& (cur_mask & (FDW_WRITE | FDW_WRITE_ONESHOT))*/) {
+
+    //new_mask &= ~FDW_WRITE_ONESHOT;
+    result |= FDW_WRITE;
+  }
+
+  //if (new_mask == old_mask)
+  //  return result;
+
+  //fdw->fd_rw_pending[fd] = new_mask;
+
+  // Nessun interesse rimanente (né READ né WRITE, con o senza ONESHOT)
+  //if ((new_mask &
+  //     (FDW_READ | FDW_READ_ONESHOT | FDW_WRITE | FDW_WRITE_ONESHOT)) == 0) {
+  //  return result;
+  //}
+
+  // Gestione operazione pendente verso epoll
+  //EPendingOp &op = fdw->fd_pending_op[fd];
+
+  //if (fdw->fd_registered[fd] && op == FDW_OP_NONE) {
+  //  op = FDW_OP_MOD;
+  //  fdwatch_mark_dirty(fdw, fd);
+  //}
+
+  return result;
+}
+
+/* ---------------------------------------------------------------------- */
+/* fdwatch_register                                                       */
+/* - NON chiama epoll_ctl                                                 */
+/* - Aggiorna fd_rw_pending, fd_pending_op                                */
+/* ---------------------------------------------------------------------- */
+
+void fdwatch_register(LPFDWATCH fdw, int flag, int fd, int rw) {
+
+  const bool registered = fdw->fd_registered[fd];
+
+  if (flag == EV_DELETE) {
+    fdw->fd_rw_pending[fd] = 0;
+    fdw->fd_pending_op[fd] = registered ? FDW_OP_DEL : FDW_OP_NONE;
+    fdwatch_mark_dirty(fdw, fd);
+    return;
+  }
+
+  if (flag & EV_ADD) {
+
+    int new_mask = fdw->fd_rw_pending[fd];
+
+    if (rw == FDW_READ) {
+      // prima togli entrambe le varianti, poi imposti quella giusta
+      new_mask &= ~(FDW_READ | FDW_READ_ONESHOT);
+      new_mask |= (flag & EV_ONESHOT) ? FDW_READ_ONESHOT : FDW_READ;
+
+    } else if (rw == FDW_WRITE) {
+      new_mask &= ~(FDW_WRITE | FDW_WRITE_ONESHOT);
+      new_mask |= (flag & EV_ONESHOT) ? FDW_WRITE_ONESHOT : FDW_WRITE;
+    }
+
+    fdw->fd_rw_pending[fd] = new_mask;
+    fdw->fd_pending_op[fd] = registered ? FDW_OP_MOD : FDW_OP_ADD;
+    fdwatch_mark_dirty(fdw, fd);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+/* fdwatch_insert_fd                                                      */
+/* - Inizializza le strutture interne per un nuovo fd (es. dopo accept()) */
+/* - Azzera lo stato eventualmente residuo su quel numero di fd           */
+/*   (riuso di descrittori già chiusi)                                    */
+/* - Marca il fd come da aggiungere a epoll alla prossima fdwatch()       */
+/* - NON imposta interessi READ/WRITE: vanno configurati con              */
+/*   fdwatch_add_fd() / fdwatch_register()                                */
+/* ---------------------------------------------------------------------- */
+
+void fdwatch_insert_fd(LPFDWATCH fdw, socket_t fd) {
+  if ((fd < 0) || (fd >= fdw->nfiles))
+    return;
+
+  fdw->fd_registered[fd] = false;
+  fdw->fd_rw_pending[fd] = 0;
+  fdw->fd_pending_op[fd] = FDW_OP_ADD;
+  fdw->fd_data[fd] = nullptr;
+  fdwatch_mark_dirty(fdw, fd);
+}
+
+/* ---------------------------------------------------------------------- */
+/* fdwatch_add_fd                                                         */
+/* - Solo gestione strutture dati                                         */
+/* ---------------------------------------------------------------------- */
+
+void fdwatch_add_fd(LPFDWATCH fdw, socket_t fd, void *client_data, int rw,
+                    int oneshot) {
+
+  if ((fd < 0) || (fd >= fdw->nfiles)) {
+    return;
+  }
+
+  int flag = EV_ADD | (oneshot ? EV_ONESHOT : 0);
+
+  fdw->fd_data[fd] = client_data;
+  fdwatch_register(fdw, flag, fd, rw);
+}
+
+/* ---------------------------------------------------------------------- */
+/* ACCESSORI                                                              */
+/* ---------------------------------------------------------------------- */
+
+void *fdwatch_get_client_data(LPFDWATCH fdw, unsigned int event_idx) {
+  if (event_idx >= (unsigned int)fdw->nevents)
+    return nullptr;
+
+  int fd = fdw->events[event_idx].data.fd;
+
+  if (fd < 0 || fd >= fdw->nfiles)
+    return nullptr;
+
+  return fdw->fd_data[fd];
+}
+
+void fdwatch_clear_fd(LPFDWATCH fdw, socket_t fd) {
+  if (fd < 0 || fd >= fdw->nfiles)
+    return;
+
+  // fdw->fd_registered[fd] = false;
+  fdw->fd_rw_current[fd] = 0;
+  // fdw->fd_rw_pending[fd] = 0;
+  // fdw->fd_pending_op[fd] = FDW_OP_NONE;
+  fdw->fd_data[fd] = nullptr;
+}
+
+void fdwatch_del_fd(LPFDWATCH fdw, socket_t fd) {
+  if (fd < 0 || fd >= fdw->nfiles)
+    return;
+
+  // Gestito come EV_DELETE: segniamo solo la DEL pendente
+  fdwatch_register(fdw, EV_DELETE, fd, 0);
+  fdwatch_clear_fd(fdw, fd);
+}
+
+void fdwatch_clear_event(LPFDWATCH fdw, socket_t fd, unsigned int event_idx) {
+  (void)fdw;
+  (void)fd;
+  (void)event_idx;
+  return; // PLACEHOLDER
+}
+
+int fdwatch_get_ident(LPFDWATCH fdw, unsigned int event_idx) {
+  (void)fdw;
+  (void)event_idx;
+  return 0; // PLACEHOLDER
+}
+
+int fdwatch_get_buffer_size(LPFDWATCH fdw, socket_t fd) {
+  (void)fdw;
+  (void)fd;
+  return INT_MAX; // placeholder
+}
 #endif


### PR DESCRIPTION
**Title:**
Add full Linux support with fdwatch using epoll

**Description:**
This PR adds complete support for Linux by implementing a custom fdwatch mechanism. It aims to replicate the behavior of kqueue as closely as possible using epoll.

**Key points:**
- Full Linux compatibility for file descriptor monitoring
- fdwatch implementation tailored for Linux
- Designed to mimic kqueue behavior for consistency across platforms
