### PR TITLE
Revert onaftercreated  function for those having issues with it

### DIFF
--- a/src/game/item.cpp
+++ b/src/game/item.cpp
@@ -1436,6 +1436,18 @@ EVENTFUNC(real_time_expire_event)
 
 	if (current > item->GetSocket(0))
 	{
+	LPCHARACTER owner = item->GetOwner();
+	//##########################################
+		if (owner && owner->GetDesc())
+		{
+			LPDESC d = owner->GetDesc();
+			
+			if (d->IsPhase(PHASE_LOADING))
+			{								
+				return PASSES_PER_SEC(1);	
+			}								
+		}									
+	//##########################################
 		switch (item->GetVnum())
 		{
 			if(item->IsNewMountItem())
@@ -2001,16 +2013,6 @@ bool CItem::OnAfterCreatedItem()
 		// Socket1에 아이템의 사용 횟수가 기록되어 있으니, 한 번이라도 사용한 아이템은 타이머를 시작한다.
 		if (0 != GetSocket(1))
 		{
-			// Check if item has already expired before starting the event
-			const time_t current = get_global_time();
-			if (current > GetSocket(0))
-			{
-				// Item has already expired while player was offline
-				// Remove it immediately to prevent crash during login
-				ITEM_MANAGER::instance().RemoveItem(this, "REAL_TIME_EXPIRE (expired offline)");
-				return false;
-			}
-
 			StartRealTimeExpireEvent();
 		}
 	}


### PR DESCRIPTION
Since some of you said there s an issue with the fix on onaftercreateditem, causing errors. To my understanding the issue is timing, the item_del is sent at the wrong time when client isn t ready yet. A small delay of 1 sec seems to fix it without any issues nor syserrs. I'll do a summarized explanation of what it does below: When real time expire function is called it checks in which phase the player is currently in, if in phase_loading(where crash occurs) it calls the event again after one second. If not in phase loading then it skips the block and deletes the item immediately. If you're wondering if it can be exploited it cannot. No desc -> player disconnecting during loading phase item doesn't reach the actual deletion phase, logs in again onaftercreateditem is called -> calls startrealtimeexpireevent which starts the event again.