### PR TITLE
Set Cmake C standard, fixing build issues with gcc15+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 project(m2dev-server-src)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_C_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ASan support


### PR DESCRIPTION
gcc15 changes the default c version from gnu17 to gnu23, which adds bool as a keyword. This project uses `typedef char bool` in a few places which will not compile with gnu23.