### PR TITLE
Always send computed points

### DIFF
--- a/src/game/char.cpp
+++ b/src/game/char.cpp
@@ -1616,10 +1616,7 @@ void CHARACTER::PointsPacket()
 	pack.points[POINT_STAMINA]		= GetStamina();
 	pack.points[POINT_MAX_STAMINA]	= GetMaxStamina();
 
-	for (int i = POINT_ST; i < POINT_IQ + 1; ++i)
-		pack.points[i] = GetRealPoint(i);
-
-	for (int i = POINT_IQ + 1; i < POINT_MAX_NUM; ++i)
+	for (int i = POINT_ST; i < POINT_MAX_NUM; ++i)
 		pack.points[i] = GetPoint(i);
 
 	GetDesc()->Packet(&pack, sizeof(TPacketGCPoints));


### PR DESCRIPTION
Problem fixed:
- Stats were wrong and did not account for equipment after login. You'd need to re-equip everything to have the updated stats.

This is part 2/2 (the other one is in client-src)
Some code copied over taken from the forum was conflicting with another copy-pasta from the forum

MRMJ-1 and MR-3 code was keeping the two parts of the code to not working as needed.

This sends the computed values in the points change packet, so it is always pre-loaded with the updated values.
Without merging the client-src part, this will lead to have always the updated values even in character loading screen.